### PR TITLE
file_renamer in MangaTaggerLib.py unable to parse chapters 100+

### DIFF
--- a/MangaTaggerLib/MangaTaggerLib.py
+++ b/MangaTaggerLib/MangaTaggerLib.py
@@ -153,10 +153,10 @@ def file_renamer(filename, logging_info):
     try:
         if chapter_title.find('chapter') > -1:
             delimiter = 'chapter'
-            delimiter_index = 8
+            delimiter_index = 7
         elif chapter_title.find('ch.') > -1:
             delimiter = 'ch.'
-            delimiter_index = 4
+            delimiter_index = 3
         else:
             raise UnparsableFilenameError(filename, 'ch/chapter')
     except UnparsableFilenameError as ufe:


### PR DESCRIPTION
## Description
After some tweaking to get things working in my setup I found that the file_renamer had some trouble with parsing chapters that go above 100.

## Current Behaviour
A file that is successfully parsed does not include the first integer looping them back around:
```
2020-12-09 17:26:33,096 | MTT-6 21020 | MangaTaggerLib.MangaTaggerLib | INFO - Filename was successfully parsed as ['Kanojo, Okarishimasu', 'Ch.100.cbz'].
2020-12-09 17:26:33,114 | MTT-6 21020 | MangaTaggerLib.MangaTaggerLib | DEBUG - manga_title: Kanojo, Okarishimasu
2020-12-09 17:26:33,132 | MTT-6 21020 | MangaTaggerLib.MangaTaggerLib | DEBUG - chapter: ch.100
2020-12-09 17:26:33,150 | MTT-6 21020 | MangaTaggerLib.MangaTaggerLib | DEBUG - delimiter: ch.
2020-12-09 17:26:33,162 | MTT-6 21020 | MangaTaggerLib.MangaTaggerLib | DEBUG - delimiter_index: 4
2020-12-09 17:26:33,180 | MTT-6 21020 | MangaTaggerLib.MangaTaggerLib | DEBUG - Iterator i: 4
2020-12-09 17:26:33,198 | MTT-6 21020 | MangaTaggerLib.MangaTaggerLib | DEBUG - Length: 6
2020-12-09 17:26:33,216 | MTT-6 21020 | MangaTaggerLib.MangaTaggerLib | DEBUG - substring: 0
2020-12-09 17:26:33,234 | MTT-6 21020 | MangaTaggerLib.MangaTaggerLib | DEBUG - chapter_number: 0
2020-12-09 17:26:33,252 | MTT-6 21020 | MangaTaggerLib.MangaTaggerLib | DEBUG - Iterator i: 5
2020-12-09 17:26:33,270 | MTT-6 21020 | MangaTaggerLib.MangaTaggerLib | DEBUG - substring: 0
2020-12-09 17:26:33,288 | MTT-6 21020 | MangaTaggerLib.MangaTaggerLib | DEBUG - chapter_number: 00
2020-12-09 17:26:33,306 | MTT-6 21020 | MangaTaggerLib.MangaTaggerLib | DEBUG - Iterator i: 6
2020-12-09 17:26:33,324 | MTT-6 21020 | MangaTaggerLib.MangaTaggerLib | DEBUG - chapter_number: 000
2020-12-09 17:26:33,342 | MTT-6 21020 | MangaTaggerLib.MangaTaggerLib | INFO - File will be renamed to "Kanojo, Okarishimasu 000.cbz".
```
## How Has This Been Tested?
After the change a handful of files above 100 were tested:
```
2020-12-09 17:56:30,466 | MTT-7 31660 | MangaTaggerLib.MangaTaggerLib | INFO - Filename was successfully parsed as ['Kanojo, Okarishimasu', 'Ch.100.cbz'].
2020-12-09 17:56:30,466 | MTT-7 31660 | MangaTaggerLib.MangaTaggerLib | DEBUG - manga_title: Kanojo, Okarishimasu
2020-12-09 17:56:30,466 | MTT-7 31660 | MangaTaggerLib.MangaTaggerLib | DEBUG - chapter: ch.100
2020-12-09 17:56:30,466 | MTT-7 31660 | MangaTaggerLib.MangaTaggerLib | DEBUG - delimiter: ch.
2020-12-09 17:56:30,466 | MTT-7 31660 | MangaTaggerLib.MangaTaggerLib | DEBUG - delimiter_index: 3
2020-12-09 17:56:30,466 | MTT-7 31660 | MangaTaggerLib.MangaTaggerLib | DEBUG - Iterator i: 3
2020-12-09 17:56:30,466 | MTT-7 31660 | MangaTaggerLib.MangaTaggerLib | DEBUG - Length: 6
2020-12-09 17:56:30,467 | MTT-7 31660 | MangaTaggerLib.MangaTaggerLib | DEBUG - substring: 1
2020-12-09 17:56:30,467 | MTT-7 31660 | MangaTaggerLib.MangaTaggerLib | DEBUG - chapter_number: 1
2020-12-09 17:56:30,467 | MTT-7 31660 | MangaTaggerLib.MangaTaggerLib | DEBUG - Iterator i: 4
2020-12-09 17:56:30,467 | MTT-7 31660 | MangaTaggerLib.MangaTaggerLib | DEBUG - substring: 0
2020-12-09 17:56:30,467 | MTT-7 31660 | MangaTaggerLib.MangaTaggerLib | DEBUG - chapter_number: 10
2020-12-09 17:56:30,468 | MTT-7 31660 | MangaTaggerLib.MangaTaggerLib | DEBUG - Iterator i: 5
2020-12-09 17:56:30,468 | MTT-7 31660 | MangaTaggerLib.MangaTaggerLib | DEBUG - substring: 0
2020-12-09 17:56:30,468 | MTT-7 31660 | MangaTaggerLib.MangaTaggerLib | DEBUG - chapter_number: 100
2020-12-09 17:56:30,468 | MTT-7 31660 | MangaTaggerLib.MangaTaggerLib | DEBUG - Iterator i: 6
2020-12-09 17:56:30,468 | MTT-7 31660 | MangaTaggerLib.MangaTaggerLib | DEBUG - chapter_number: 100
2020-12-09 17:56:30,469 | MTT-7 31660 | MangaTaggerLib.MangaTaggerLib | INFO - File will be renamed to "Kanojo, Okarishimasu 100.cbz".
```
Now that it is looking in the right place it should be able to handle any number that is thrown at it. A quick test below shows that:

![image](https://user-images.githubusercontent.com/1612837/101671081-eee6e680-3a4b-11eb-80d5-842a5c19ee0e.png)

After the change I managed to continue tagging Kanojo, Okarishimasu up from 100 to 167 without any issue.