### PR TITLE
Add Task Queue Saving Feature

### DIFF
--- a/MangaTaggerLib/MangaTaggerLib.py
+++ b/MangaTaggerLib/MangaTaggerLib.py
@@ -173,9 +173,6 @@ def file_renamer(filename, logging_info):
                 delimiter_index = 2
             else:
                 delimiter_index = 3
-        elif compare(manga_title, chapter_title) > .5 and compare(manga_title, chapter_title[:len(manga_title)]) > .8:
-            delimiter = manga_title.lower()
-            delimiter_index = len(manga_title) + 1
         else:
             raise UnparsableFilenameError(filename, 'ch/chapter')
     except UnparsableFilenameError as ufe:

--- a/MangaTaggerLib/database.py
+++ b/MangaTaggerLib/database.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 from datetime import datetime
+from queue import Queue
 
 from bson.errors import InvalidDocument
 from pymongo import MongoClient
@@ -52,12 +53,22 @@ class Database:
         MetadataTable.initialize()
         ProcFilesTable.initialize()
         ProcSeriesTable.initialize()
+        TaskQueueTable.initialize()
 
         cls._log.info('Database connection established!')
-        cls._log.debug(f'{cls.__name__} class has been initialized.')
+        cls._log.debug(f'{cls.__name__} class has been initialized')
+
+    @classmethod
+    def load_database_tables(cls):
+        ProcSeriesTable.load()
+
+    @classmethod
+    def save_database_tables(cls):
+        ProcSeriesTable.save()
 
     @classmethod
     def close_connection(cls):
+        cls._log.info('Closing database connection...')
         cls._client.close()
 
     @classmethod
@@ -109,7 +120,7 @@ class MetadataTable(Database):
     def initialize(cls):
         cls._log = logging.getLogger(f'{cls.__module__}.{cls.__name__}')
         cls._database = super()._database['manga_metadata']
-        cls._log.debug(f'{cls.__name__} class has been initialized.')
+        cls._log.debug(f'{cls.__name__} class has been initialized')
 
     @classmethod
     def search_by_search_value(cls, manga_title):
@@ -139,7 +150,7 @@ class ProcFilesTable(Database):
     def initialize(cls):
         cls._log = logging.getLogger(f'{cls.__module__}.{cls.__name__}')
         cls._database = super()._database['processed_files']
-        cls._log.debug(f'{cls.__name__} class has been initialized.')
+        cls._log.debug(f'{cls.__name__} class has been initialized')
 
     @classmethod
     def search(cls, manga_title, chapter_number):
@@ -152,34 +163,63 @@ class ProcFilesTable(Database):
 
 
 class ProcSeriesTable(Database):
+    processed_series = set()
+
     @classmethod
     def initialize(cls):
         cls._log = logging.getLogger(f'{cls.__module__}.{cls.__name__}')
         cls._database = super()._database['processed_series']
         cls._id = None
         cls._last_save_time = None
-        cls._log.debug(f'{cls.__name__} class has been initialized.')
+        cls._log.debug(f'{cls.__name__} class has been initialized')
 
     @classmethod
-    def save(cls, processed_series):
+    def save(cls):
+        cls._log.info('Saving processed series...')
         cls._database.delete_one({
             '_id': cls._id
         })
-        super(ProcSeriesTable, cls).insert(dict.fromkeys(processed_series, True))
+        super(ProcSeriesTable, cls).insert(dict.fromkeys(cls.processed_series, True))
 
     @classmethod
     def load(cls):
+        cls._log.info('Loading processed series...')
         results = cls._database.find_one()
         if results is not None:
             cls._id = results.pop('_id')
-            return set(results.keys())
+            cls.processed_series = set(results.keys())
 
     @classmethod
-    def save_while_running(cls, processed_series):
+    def save_while_running(cls):
         if cls._last_save_time is not None:
             last_save_delta = (datetime.now() - cls._last_save_time).total_seconds()
 
             # Save every hour
             if last_save_delta > 3600:
                 cls._last_save_time = datetime.now()
-                cls.save(processed_series)
+                cls.save()
+
+
+class TaskQueueTable(Database):
+    @classmethod
+    def initialize(cls):
+        cls._log = logging.getLogger(f'{cls.__module__}.{cls.__name__}')
+        cls._database = super()._database['task_queue']
+        cls.queue = Queue()
+        cls._log.debug(f'{cls.__name__} class has been initialized')
+
+    @classmethod
+    def load(cls, queue):
+        cls._log.info('Loading task queue...')
+        results = cls._database.find()
+
+        if results is not None:
+            for result in results:
+                queue.put(result, True)
+
+    @classmethod
+    def save(cls, queue):
+        if not queue.empty():
+            cls._log.info('Saving task queue...')
+            while not queue.empty():
+                super(TaskQueueTable, cls).insert(queue.get().__dict__)

--- a/MangaTaggerLib/database.py
+++ b/MangaTaggerLib/database.py
@@ -114,6 +114,19 @@ class Database:
 
         cls._log.info('Update was successful!', extra=logging_info)
 
+    @classmethod
+    def delete_all(cls, logging_info):
+        try:
+            cls._log.info('Attempting to delete all records in the database...', extra=logging_info)
+            cls._database.delete_many({})
+        except Exception as e:
+            cls._log.exception(e, extra=logging_info)
+            cls._log.warning('Manga Tagger is unfamiliar with this error. Please log an issue for investigation.',
+                             extra=logging_info)
+            return
+
+        cls._log.info('Deletion was successful!', extra=logging_info)
+
 
 class MetadataTable(Database):
     @classmethod
@@ -209,13 +222,13 @@ class TaskQueueTable(Database):
         cls._log.debug(f'{cls.__name__} class has been initialized')
 
     @classmethod
-    def load(cls, queue):
+    def load(cls, task_list: list):
         cls._log.info('Loading task queue...')
         results = cls._database.find()
 
         if results is not None:
             for result in results:
-                queue.put(result, True)
+                task_list.append(result)
 
     @classmethod
     def save(cls, queue):
@@ -223,3 +236,7 @@ class TaskQueueTable(Database):
             cls._log.info('Saving task queue...')
             while not queue.empty():
                 super(TaskQueueTable, cls).insert(queue.get().__dict__)
+
+    @classmethod
+    def delete_all(cls):
+        super(TaskQueueTable, cls).delete_all(None)

--- a/MangaTaggerLib/task_queue.py
+++ b/MangaTaggerLib/task_queue.py
@@ -1,0 +1,160 @@
+import logging
+import time
+import uuid
+from ntpath import dirname, getsize
+from queue import Queue
+from threading import Thread
+from typing import List
+
+from watchdog.events import PatternMatchingEventHandler
+from watchdog.observers import Observer
+from watchdog.observers.polling import PollingObserver
+
+from MangaTaggerLib import MangaTaggerLib
+from MangaTaggerLib.database import TaskQueueTable
+
+
+class QueueEvent:
+    def __init__(self, event, from_db=False):
+        if not from_db:
+            self.event_type = event.event_type
+            self.src_path = event.src_path
+            try:
+                self.dest_path = event.dest_path
+            except AttributeError:
+                pass
+        else:
+            self.event_type = event['event_type']
+            self.src_path = event['src_path']
+            try:
+                self.dest_path = event['dest_path']
+            except KeyError:
+                pass
+
+    def __str__(self):
+        if self.event_type == 'created':
+            return f'File {self.event_type} event at {self.src_path}'
+        elif self.event_type == 'modified':
+            return f'File {self.event_type} event at {self.dest_path}'
+
+
+class QueueWorker:
+    _queue: Queue = None
+    _observer: Observer = None
+    _log: logging = None
+    _worker_list: List[Thread] = None
+
+    max_queue_size = None
+    threads = None
+    is_library_network_path = False
+    download_dir = None
+
+    @classmethod
+    def initialize(cls):
+        cls._log = logging.getLogger(f'{cls.__module__}.{cls.__name__}')
+        cls._queue = Queue()
+        cls._observer = Observer()
+        cls._worker_list = []
+
+    @classmethod
+    def load(cls):
+        TaskQueueTable.load(cls._queue)
+
+    @classmethod
+    def save(cls):
+        TaskQueueTable.save(cls._queue)
+
+    @classmethod
+    def exit(cls):
+        cls._log.info('Stopping worker threads...')
+        for worker in cls._worker_list:
+            worker.join()
+
+        cls._log.debug('Stopping watchdog...')
+        cls._observer.stop()
+        cls._observer.join()
+
+    @classmethod
+    def run(cls):
+        cls._log = logging.getLogger(f'{cls.__module__}.{cls.__name__}')
+        cls._queue = Queue(maxsize=cls.max_queue_size)
+        for i in range(cls.threads):
+            worker = Thread(target=cls.process, name=f'MTT-{i}', daemon=True)
+            cls._log.debug(f'Worker thread {worker.name} has been initialized')
+            cls._worker_list.append(worker)
+            worker.start()
+
+        if cls.is_library_network_path:
+            cls._observer = PollingObserver()
+
+        cls._observer.schedule(SeriesHandler(cls._queue), cls.download_dir, True)
+        cls._observer.start()
+
+        cls._log.info(f'Watching "{cls.download_dir}" for new downloads')
+
+    @classmethod
+    def process(cls):
+        while True:
+            if not cls._queue.empty():
+                event = cls._queue.get()
+
+                if event.event_type == 'created':
+                    cls._log.info(f'Pulling "file {event.event_type}" event from the queue for "{event.src_path}"')
+                    path = event.src_path
+                elif event.event_type == 'moved':
+                    cls._log.info(f'Pulling "file {event.event_type}" event from the queue for "{event.dest_path}"')
+                    path = event.dest_path
+                else:
+                    cls._log.error('Event was passed, but Manga Tagger does not know how to handle it. Please open an '
+                                   'issue for further investigation.')
+
+                current_size = -1
+                try:
+                    while current_size != getsize(path):
+                        current_size = getsize(path)
+                        time.sleep(1)
+                except FileNotFoundError as fnfe:
+                    cls._log.exception(fnfe)
+
+                try:
+                    MangaTaggerLib.process_manga_chapter(path, uuid.uuid1())
+                except Exception as e:
+                    cls._log.exception(e)
+                    cls._log.warning('Manga Tagger is unfamiliar with this error. Please log an issue for '
+                                     'investigation.')
+
+                cls._queue.task_done()
+
+
+class SeriesHandler(PatternMatchingEventHandler):
+    _log = None
+
+    @classmethod
+    def class_name(cls):
+        return cls.__name__
+
+    @classmethod
+    def fully_qualified_class_name(cls):
+        return f'{cls.__module__}.{cls.__name__}'
+
+    def __init__(self, queue):
+        self._log = logging.getLogger(self.fully_qualified_class_name())
+        super().__init__(patterns=['*.cbz'])
+        self.queue = queue
+        self._log.debug(f'{self.class_name()} class has been initialized')
+
+    def on_created(self, event):
+        self._log.debug(f'Event Type: {event.event_type}')
+        self._log.debug(f'Event Path: {event.src_path}')
+
+        self.queue.put(QueueEvent(event))
+        self._log.info(f'Creation event for "{event.src_path}" will be added to the queue')
+
+    def on_moved(self, event):
+        self._log.debug(f'Event Type: {event.event_type}')
+        self._log.debug(f'Event Source Path: {event.src_path}')
+        self._log.debug(f'Event Destination Path: {event.dest_path}')
+
+        if dirname(event.src_path) == dirname(event.dest_path) and '-.-' in event.dest_path:
+            self.queue.put(QueueEvent(event))
+        self._log.info(f'Moved event for "{event.dest_path}" will be added to the queue')

--- a/MangaTaggerLib/task_queue.py
+++ b/MangaTaggerLib/task_queue.py
@@ -57,8 +57,14 @@ class QueueWorker:
         cls._worker_list = []
 
     @classmethod
-    def load(cls):
-        TaskQueueTable.load(cls._queue)
+    def load_task_queue(cls):
+        task_list = []
+        TaskQueueTable.load(task_list)
+
+        for task in task_list:
+            cls._queue.put(QueueEvent(task, True))
+
+        TaskQueueTable.delete_all()
 
     @classmethod
     def save(cls):

--- a/MangaTaggerLib/task_queue.py
+++ b/MangaTaggerLib/task_queue.py
@@ -52,7 +52,7 @@ class QueueWorker:
     @classmethod
     def initialize(cls):
         cls._log = logging.getLogger(f'{cls.__module__}.{cls.__name__}')
-        cls._queue = Queue()
+        cls._queue = Queue(maxsize=cls.max_queue_size)
         cls._observer = Observer()
         cls._worker_list = []
 
@@ -77,7 +77,6 @@ class QueueWorker:
     @classmethod
     def run(cls):
         cls._log = logging.getLogger(f'{cls.__module__}.{cls.__name__}')
-        cls._queue = Queue(maxsize=cls.max_queue_size)
         for i in range(cls.threads):
             worker = Thread(target=cls.process, name=f'MTT-{i}', daemon=True)
             cls._log.debug(f'Worker thread {worker.name} has been initialized')

--- a/MangaTaggerLib/utils.py
+++ b/MangaTaggerLib/utils.py
@@ -107,7 +107,7 @@ class AppSettings:
 
         # Initialize QueueWorker and load task queue
         QueueWorker.initialize()
-        QueueWorker.load()
+        QueueWorker.load_task_queue()
 
         # Register function to be run prior to application termination
         atexit.register(cls._exit_handler)

--- a/MangaTaggerLib/utils.py
+++ b/MangaTaggerLib/utils.py
@@ -2,25 +2,16 @@ import atexit
 import json
 import logging
 import os
-import pickle
 import subprocess
 import sys
-import time
-import uuid
 from logging.handlers import RotatingFileHandler, SocketHandler
-from ntpath import dirname, getsize
-from queue import Queue
-from threading import Thread
 
 import numpy
 from configparser import ConfigParser
 from pythonjsonlogger import jsonlogger
-from watchdog.events import PatternMatchingEventHandler
-from watchdog.observers import Observer
-from watchdog.observers.polling import PollingObserver
 
-from MangaTaggerLib import MangaTaggerLib
-from MangaTaggerLib.database import Database, ProcSeriesTable
+from MangaTaggerLib.database import Database
+from MangaTaggerLib.task_queue import QueueWorker
 
 
 class AppSettings:
@@ -28,10 +19,6 @@ class AppSettings:
     timezone = None
     version = None
 
-    threads = None
-    max_queue_size = None
-
-    download_dir = None
     library_dir = None
     is_network_path = None
 
@@ -85,18 +72,18 @@ class AppSettings:
 
         # Multithreading Configuration
         if settings['application']['multithreading']['threads'] <= 0:
-            cls.threads = 1
+            QueueWorker.threads = 1
         else:
-            cls.threads = settings['application']['multithreading']['threads']
+            QueueWorker.threads = settings['application']['multithreading']['threads']
 
-        cls._log.debug(f'Threads: {cls.threads}')
+        cls._log.debug(f'Threads: {QueueWorker.threads}')
 
         if settings['application']['multithreading']['max_queue_size'] < 0:
-            cls.max_queue_size = 0
+            QueueWorker.max_queue_size = 0
         else:
-            cls.max_queue_size = settings['application']['multithreading']['max_queue_size']
+            QueueWorker.max_queue_size = settings['application']['multithreading']['max_queue_size']
 
-        cls._log.debug(f'Max Queue Size: {cls.max_queue_size}')
+        cls._log.debug(f'Max Queue Size: {QueueWorker.max_queue_size}')
 
         # Manga Library Configuration
         if settings['application']['library']['dir'] is not None:
@@ -115,14 +102,16 @@ class AppSettings:
                               'files into. Configure one in the "settings.json" and try again.')
             sys.exit(1)
 
-        # Load processed database series
-        cls.processed_series = ProcSeriesTable.load()
-        if cls.processed_series is None:
-            cls.processed_series = set()
+        # Load necessary database tables
+        Database.load_database_tables()
+
+        # Initialize QueueWorker and load task queue
+        QueueWorker.initialize()
+        QueueWorker.load()
 
         # Register function to be run prior to application termination
         atexit.register(cls._exit_handler)
-        cls._log.debug(f'{cls.__name__} class has been initialized.')
+        cls._log.debug(f'{cls.__name__} class has been initialized')
 
     @classmethod
     def grant_permissions(cls, dir_name, print_output=True):
@@ -162,12 +151,12 @@ class AppSettings:
 
         # DEVELOPMENT ONLY SETTING
         if download_dir is None:
-            cls.download_dir = settings_json['saveto']['SaveTo']
-            cls._log.debug(f'Download directory has been set as "{cls.download_dir}"')
+            QueueWorker.download_dir = settings_json['saveto']['SaveTo']
+            cls._log.debug(f'Download directory has been set as "{QueueWorker.download_dir}"')
         else:
-            cls.download_dir = download_dir
+            QueueWorker.download_dir = download_dir
             cls._log.debug(
-                f'Download directory has been overridden and set as "{cls.download_dir}"')
+                f'Download directory has been overridden and set as "{QueueWorker.download_dir}"')
 
         if changes_made:
             with open(f'{fmd_dir}\\userdata\\settings.json', 'w') as fmd_settings:
@@ -245,115 +234,19 @@ class AppSettings:
     def _exit_handler(cls):
         cls._log.info('Initiating shutdown procedures...')
 
-        # Save processed series
-        cls._log.info('Dumping processed series...')
-        ProcSeriesTable.save(cls.processed_series)
+        # Stop worker threads
+        QueueWorker.exit()
+
+        # Save necessary database tables
+        Database.save_database_tables()
+
+        # Save current task queue
+        QueueWorker.save()
 
         # Close MongoDB connection
-        cls._log.info('Closing MongoDB connection...')
         Database.close_connection()
 
         cls._log.info('Now exiting Manga Tagger')
-
-
-class SeriesHandler(PatternMatchingEventHandler):
-    _log = None
-
-    @classmethod
-    def class_name(cls):
-        return cls.__name__
-
-    @classmethod
-    def fully_qualified_class_name(cls):
-        return f'{cls.__module__}.{cls.__name__}'
-
-    def __init__(self, queue):
-        self._log = logging.getLogger(self.fully_qualified_class_name())
-        super().__init__(patterns=['*.cbz'])
-        self.queue = queue
-        self._log.debug(f'{self.class_name()} class has been initialized.')
-
-    def on_created(self, event):
-        self._log.debug(f'Event Type: {event.event_type}')
-        self._log.debug(f'Event Path: {event.src_path}')
-
-        self.queue.put(event)
-        self._log.info(f'Creation event for "{event.src_path}" will be added to the queue')
-
-    def on_moved(self, event):
-        self._log.debug(f'Event Type: {event.event_type}')
-        self._log.debug(f'Event Source Path: {event.src_path}')
-        self._log.debug(f'Event Destination Path: {event.dest_path}')
-
-        if dirname(event.src_path) == dirname(event.dest_path) and '-.-' in event.dest_path:
-            self.queue.put(event)
-        self._log.info(f'Moved event for "{event.dest_path}" will be added to the queue')
-
-
-class QueueWorker:
-    queue = None
-    _log = None
-
-    @classmethod
-    def run(cls):
-        cls._log = logging.getLogger(f'{cls.__module__}.{cls.__name__}')
-        cls.queue = Queue(maxsize=AppSettings.max_queue_size)
-        for i in range(AppSettings.threads):
-            worker = Thread(target=cls.process, name=f'MTT-{i}', daemon=True)
-            cls._log.debug(f'Worker thread {worker.name} has been initialized')
-            worker.start()
-
-        worker = Thread(target=ProcSeriesTable.save_while_running(AppSettings.processed_series),
-                        name=f'MTT-Processed_Series_Save', daemon=True)
-        cls._log.debug(f'Application thread {worker.name} has been initialized')
-        worker.start()
-
-        if AppSettings.is_network_path:
-            observer = PollingObserver()
-        else:
-            observer = Observer()
-        observer.schedule(SeriesHandler(cls.queue), AppSettings.download_dir, True)
-        observer.start()
-
-        cls._log.info(f'Watching "{AppSettings.download_dir}" for new downloads')
-
-        while True:
-            time.sleep(1)
-        observer.join()
-        cls.queue.join()
-
-    @classmethod
-    def process(cls):
-        while True:
-            if not cls.queue.empty():
-                event = cls.queue.get()
-
-                if event.event_type == 'created':
-                    cls._log.info(f'Pulling "file {event.event_type}" event from the queue for "{event.src_path}"')
-                    path = event.src_path
-                elif event.event_type == 'moved':
-                    cls._log.info(f'Pulling "file {event.event_type}" event from the queue for "{event.dest_path}"')
-                    path = event.dest_path
-                else:
-                    cls._log.error('Event was passed, but Manga Tagger does not know how to handle it. Please open an '
-                                   'issue for further investigation.')
-
-                current_size = -1
-                try:
-                    while current_size != getsize(path):
-                        current_size = getsize(path)
-                        time.sleep(1)
-                except FileNotFoundError as fnfe:
-                    cls._log.exception(fnfe)
-
-                try:
-                    MangaTaggerLib.process_manga_chapter(path, uuid.uuid1())
-                except Exception as e:
-                    cls._log.exception(e)
-                    cls._log.warning('Manga Tagger is unfamiliar with this error. Please log an issue for '
-                                     'investigation.')
-
-                cls.queue.task_done()
 
 
 def compare(s1, s2):

--- a/MangaTaggerLib/utils.py
+++ b/MangaTaggerLib/utils.py
@@ -240,9 +240,6 @@ class AppSettings:
         # Save necessary database tables
         Database.save_database_tables()
 
-        # Save current task queue
-        QueueWorker.save()
-
         # Close MongoDB connection
         Database.close_connection()
 


### PR DESCRIPTION
When the application exits, the current task queue will be dumped to the database. Upon starting the application, the task queue will be read from the database to continue processing from a previous run.